### PR TITLE
Removes the link for the Spanish locale but leaves the assets

### DIFF
--- a/app/views/pages/_locale.html.erb
+++ b/app/views/pages/_locale.html.erb
@@ -1,6 +1,3 @@
 <% if I18n.locale != :en %>
   <%= link_to "English", url_for(locale: :en), class: "toolbar__item text--small link--subtle" %>
 <% end %>
-<% if I18n.locale != :es %>
-  <%= link_to "Español", url_for(locale: :es), class: "toolbar__item text--small link--subtle" %>
-<% end %>

--- a/spec/features/info_page_spec.rb
+++ b/spec/features/info_page_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Info page', type: :feature do
-  it 'switches language to Spanish' do
+  skip 'switches language to Spanish' do
     visit '/en/info'
     click_on 'Español'
     expect(page).to have_text 'Información sobre P-EBT'


### PR DESCRIPTION
We've been asked to pull down the links for the Spanish locale since we don't have that ready and want to launch the landing page. The locale and assets are still available for us to be able to quickly put them back up by reverting this.