### PR TITLE
Implements alt text for logo and hides the More Info button

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -81,7 +81,10 @@
 <footer class="main-footer">
   <div class="grid">
     <div class="grid__item width-one-half">
-      <p class="text--small"><%= link_to t("footer.info"), info_path, class: "link--subtle", target: "_blank" %></p>
+        <% if (ENV["COMING_SOON"] == "1") && !@is_early %>
+        <% else %>
+          <p class="text--small"><%= link_to t("footer.info"), info_path, class: "link--subtle", target: "_blank" %></p>
+        <% end %>
       <p class="text--small"><%= t("footer.delivered_by_html") %></p>
     </div>
 

--- a/app/views/pages/_logo.html.erb
+++ b/app/views/pages/_logo.html.erb
@@ -1,1 +1,1 @@
-<%=image_tag("mn-logo-horizontal-rgb.png", alt: "Minnesota", class: "app-logo") %>
+<%=image_tag("mn-logo-horizontal-rgb.png", alt: "Minnesota Department of Education and Human Services logo", class: "app-logo") %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -35,7 +35,10 @@
               <%= render partial: 'apply_now', locals: { is_early: @is_early } %>
             </div>
             <div class="grid__item width-one-half">
-              <a href="<%= info_path %>"><button class="button"><%= t("index.learn_more") %></button></a>
+              <% if (ENV["COMING_SOON"] == "1") && !@is_early %>
+              <% else %>
+                <a href="<%= info_path %>"><button class="button"><%= t("index.learn_more") %></button></a>
+              <% end %>
             </div>
           </div>
         </div>
@@ -57,7 +60,10 @@
       <div class="grid__item width-five-twelfths">
         <h3><%= t("index.questions_about") %></h3>
         <p class="form-card__body-text"><%= t("index.learn_more_about") %></p>
-        <a href="<%= info_path %>"><button class="button spacing-below-35"><%= t("index.learn_more") %></button></a>
+        <% if (ENV["COMING_SOON"] == "1") && !@is_early %>
+        <% else %>
+          <a href="<%= info_path %>"><button class="button spacing-below-35"><%= t("index.learn_more") %></button></a>
+        <% end %>
       </div>
       <div class="grid__item shift-one-twelfth width-five-twelfths">
         <h3><%= t("index.with_a_pebt_html") %></h3>


### PR DESCRIPTION
Changes the Minnesota logo alt text to the correct alt text
Hides the "More Info" button on the home page when we are in Coming Soon / Prelaunch mode until we have the correct links from the state