### PR TITLE
Speeds up CSV Export

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -7,8 +7,6 @@ class ChildrenController < FormsController
 
   def index
     @children = Child.submitted
-
-    @children = Child.submitted
     @children = @children.submitted_after(DateTime.parse(params['after'])) if params['after'].present?
     @children = @children.submitted_before(DateTime.parse(params['before'])) if params['before'].present?
     @children = @children.by_household(params['hhid']) if params['hhid'].present?

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,13 +1,13 @@
 class Child < ApplicationRecord
   belongs_to :household
 
-  scope :submitted, -> { joins(:household).where.not(households: { submitted_at: nil }) }
-  scope :unsubmitted, -> { joins(:household).where(households: { submitted_at: nil }) }
+  scope :submitted, -> { includes(:household).where.not(households: { submitted_at: nil }) }
+  scope :unsubmitted, -> { includes(:household).where(households: { submitted_at: nil }) }
 
   scope :submitted_after, ->(submitted_after_time) { submitted.where('households.submitted_at >= ?', submitted_after_time) }
   scope :submitted_before, ->(submitted_before_time) { submitted.where('households.submitted_at < ?', submitted_before_time) }
 
-  scope :by_household, ->(hhid) { joins(:household).where(households: { id: hhid }) }
+  scope :by_household, ->(hhid) { includes(:household).where(households: { id: hhid }) }
 
   def full_name
     "#{first_name} #{last_name}"


### PR DESCRIPTION
We're seeing issues where CSV Export is taking a long time to load with large numbers of records (upwards of 60 minutes). After running some performance analysis, it looks like the primary issue was that we were using `joins` which delays loading the `household` until it's called, so every child was causing an additional call to load household when we were processing records. This modifies it to be `includes` which preloads household as well and should let us take advantage of the `in_batches` loading.