### PR TITLE
Blocks going back to pages in the application once submitted

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -3,6 +3,10 @@ class FormsController < ApplicationController
   helper_method :current_household
 
   def edit
+    if current_household.submitted_at.present?
+      redirect_to(success_steps_path)
+      return
+    end
     @form = form_class.from_household(current_household)
   end
 

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -5,7 +5,7 @@ class SuccessController < FormsController
       redirect_to(children_steps_path)
       return
     end
-    super
+    @form = form_class.from_household(current_household)
   end
 
   def update

--- a/spec/features/resubmit_attempt_spec.rb
+++ b/spec/features/resubmit_attempt_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe 'Journey', type: :feature do
       click_on 'Good'
       expect(page).to have_text 'Thank you for your feedback!'
       visit mailing_address_steps_path
-      click_on 'Continue'
       expect(page).to have_text 'Your application is done!'
     end
   end


### PR DESCRIPTION
When a user lands on the confirmation page they can hit the "back" button and end back up on the signature page or any of the other pages in the application. While the forms would then let them submit data, by default we ignore that resubmit and take them back to the confirmation page.

This PR takes that one step further and redirects them back to success from any page in the journey once they've submitted. It still allows for them to start a new form, as well as to submit feedback, but hitting the back button just shows the success page.