### PR TITLE
Modifies the exporter to write all fields at once

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,3 +1,4 @@
+require 'csv'
 class ChildrenController < FormsController
   helper_method :children
   skip_before_action :check_household, only: [:index]

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -12,4 +12,60 @@ class Child < ApplicationRecord
   def full_name
     "#{first_name} #{last_name}"
   end
+
+  def csv_row
+    [
+      id,
+      first_name,
+      last_name,
+      dob,
+      school_registration_gender,
+      school_attended_name,
+      school_attended_grade,
+      household.signature,
+      household.mailing_street,
+      household.mailing_street_2,
+      household.mailing_city,
+      'MN',
+      household.mailing_zip_code,
+      household.parent_first_name,
+      household.parent_last_name,
+      household.parent_dob,
+      household.email_address,
+      household.phone_number,
+      household.language,
+      household.submitted_at,
+      household.application_experience,
+      household.experiment_group,
+      household.confirmation_code.to_s.delete('-')
+    ]
+  end
+
+  def self.csv_headers
+    %w[
+      child_id
+      student_first_name
+      student_last_name
+      student_dob
+      student_gender
+      student_school_name
+      student_school_grade
+      parent_signature
+      mailing_street
+      mailing_street_2
+      mailing_city
+      mailing_state
+      mailing_zip_code
+      parent_first_name
+      parent_last_name
+      parent_dob
+      email_address
+      phone_number
+      language
+      submitted_at
+      application_experience
+      experiment_group
+      maxis_id
+    ]
+  end
 end

--- a/app/views/children/index.csv.erb
+++ b/app/views/children/index.csv.erb
@@ -1,51 +1,7 @@
 <% # Header Row -%>
-<%= csv_field(:child_id) -%>
-<%= csv_field(:student_first_name) -%>
-<%= csv_field(:student_last_name) -%>
-<%= csv_field(:student_dob) -%>
-<%= csv_field(:student_gender) -%>
-<%= csv_field(:student_school_name) -%>
-<%= csv_field(:student_school_grade) -%>
-<%= csv_field(:parent_signature) -%>
-<%= csv_field(:mailing_street) -%>
-<%= csv_field(:mailing_street_2) -%>
-<%= csv_field(:mailing_city) -%>
-<%= csv_field(:mailing_state) -%>
-<%= csv_field(:mailing_zip_code) -%>
-<%= csv_field(:parent_first_name) -%>
-<%= csv_field(:parent_last_name) -%>
-<%= csv_field(:parent_dob) -%>
-<%= csv_field(:email_address) -%>
-<%= csv_field(:phone_number) -%>
-<%= csv_field(:language) -%>
-<%= csv_field(:submitted_at) -%>
-<%= csv_field(:application_experience) -%>
-<%= csv_field(:experiment_group) -%>
-<%= csv_field(:maxis_id, last: true) -%>
+<%= CSV.generate { |csv| csv << Child.csv_headers } -%>
 <% # Data -%>
 <%- @children.in_batches.each_record do |child| -%>
-<%= csv_field(child.id) -%>
-<%= csv_field(child.first_name) -%>
-<%= csv_field(child.last_name) -%>
-<%= csv_field(child.dob) -%>
-<%= csv_field(child.school_registration_gender) -%>
-<%= csv_field(child.school_attended_name) -%>
-<%= csv_field(child.school_attended_grade) -%>
-<%= csv_field(child.household.signature) -%>
-<%= csv_field(child.household.mailing_street) -%>
-<%= csv_field(child.household.mailing_street_2) -%>
-<%= csv_field(child.household.mailing_city) -%>
-<%= csv_field('MN') -%>
-<%= csv_field(child.household.mailing_zip_code) -%>
-<%= csv_field(child.household.parent_first_name) -%>
-<%= csv_field(child.household.parent_last_name) -%>
-<%= csv_field(child.household.parent_dob) -%>
-<%= csv_field(child.household.email_address) -%>
-<%= csv_field(child.household.phone_number) -%>
-<%= csv_field(child.household.language) -%>
-<%= csv_field(child.household.submitted_at) -%>
-<%= csv_field(child.household.application_experience) -%>
-<%= csv_field(child.household.experiment_group) -%>
-<%= csv_field(child.household.confirmation_code.to_s.gsub(/-/, ''), last: true) -%>
+<%= CSV.generate { |csv| csv << child.csv_row }.html_safe -%>
 <%- end -%>
 <%- #HACK forced data in csv -%>

--- a/lib/tasks/export.thor
+++ b/lib/tasks/export.thor
@@ -1,4 +1,5 @@
 require 'thor'
+require 'csv'
 require './config/environment' # Load Rails
 
 class Export < Thor
@@ -17,10 +18,12 @@ class Export < Thor
       puts "Exporting children submitted before #{DateTime.parse(options['before']).strftime('%B %d %Y')}"
     end
 
-    output = ChildrenController.render :index, assigns: { children: children }
     File.delete(file_name) if File.exist?(file_name)
-    File.open(file_name, 'w') do |file|
-      file.puts output
+    CSV.open(file_name, 'w') do |file|
+      file << Child.csv_headers
+      children.each do |row|
+        file << row.csv_row
+      end
     end
     puts "EXPORT COMPLETE! Exported to #{file_name}"
   end


### PR DESCRIPTION
Ok, I know I got nerdsniped on this, but this looks to have a *huge* additional speedup for exports. In profiling this, things got slow the more fields we wrote at a time. I initially set to write a custom DB query which did have a huge impact, but was difficult to get in the `before` and `after`s in a way that wasn't going to take the rest of the day.

So I thought I'd try just writing all of the fields as one getter, and it made a similar impact to the query. 

Bonus that this uses the CSV writer now, but we should compare an older file to the output of this to make sure nothing has changed in the format beyond what my testing showed.