### PR TITLE
Add Thor Commands to Export and Upload to S3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,6 +54,7 @@ RSpec/NamedSubject:
 RSpec/BeforeAfterAll:
   Exclude:
     - spec/features/export_spec.rb
+    - spec/features/upload_aws_spec.rb
 Style/Documentation:
   Enabled: false
 Style/ExponentialNotation:

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.6.3'
 
+gem 'aws-sdk-s3', '~> 1'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'cfa-styleguide', git: 'https://github.com/codeforamerica/honeycrisp-gem'
 gem 'pg', '>= 0.18', '< 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,22 @@ GEM
     ast (2.4.1)
     autoprefixer-rails (9.7.6)
       execjs
+    aws-eventstream (1.1.0)
+    aws-partitions (1.329.0)
+    aws-sdk-core (3.99.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.34.1)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.68.1)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.4)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bindex (0.8.1)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -112,6 +128,7 @@ GEM
       phantomjs (>= 1.9)
       railties (>= 3.2.0)
       sprockets-rails
+    jmespath (1.4.0)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -290,6 +307,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)

--- a/lib/tasks/export.thor
+++ b/lib/tasks/export.thor
@@ -17,14 +17,29 @@ class Export < Thor
       children = children.submitted_before(DateTime.parse(options['before']))
       puts "Exporting children submitted before #{DateTime.parse(options['before']).strftime('%B %d %Y')}"
     end
+    export(children, file_name)
+  end
 
-    File.delete(file_name) if File.exist?(file_name)
-    CSV.open(file_name, 'w') do |file|
-      file << Child.csv_headers
-      children.in_batches.each_record do |row|
-        file << row.csv_row
+  desc 'last_x_days DAYS FILE', 'Exports children from the database for the last DAYS days (defaults to 7) to FILE (defaults to tmp/all.csv). Does not include the day the script is run'
+  def last_x_days(days = 7, file_name = Rails.root.join('tmp', 'all.csv'))
+    children = Child.submitted
+    children = children.submitted_after(DateTime.now.midnight - days.to_i.days)
+    children = children.submitted_before(DateTime.now.midnight)
+    export(children, file_name)
+  end
+
+  no_commands do
+
+    def export(children, file_name)
+      File.delete(file_name) if File.exist?(file_name)
+      CSV.open(file_name, 'w') do |file|
+        file << Child.csv_headers
+        children.in_batches.each_record do |row|
+          file << row.csv_row
+        end
       end
+      puts "EXPORT COMPLETE! Exported to #{file_name}"
     end
-    puts "EXPORT COMPLETE! Exported to #{file_name}"
+
   end
 end

--- a/lib/tasks/export.thor
+++ b/lib/tasks/export.thor
@@ -29,7 +29,6 @@ class Export < Thor
   end
 
   no_commands do
-
     def export(children, file_name)
       File.delete(file_name) if File.exist?(file_name)
       CSV.open(file_name, 'w') do |file|
@@ -40,6 +39,5 @@ class Export < Thor
       end
       puts "EXPORT COMPLETE! Exported to #{file_name}"
     end
-
   end
 end

--- a/spec/features/upload_aws_spec.rb
+++ b/spec/features/upload_aws_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'Exporting Children as CSV', type: :feature do
+  SUCCESS_MESSAGE = 'Upload Complete!'.freeze
+  REDIRECT_STDERR = '2>&1'.freeze
+
+  before(:all) do
+    @aws_vars = %w[AWS_REGION AWS_EXPORT_UPLOAD_BUCKET AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY]
+    @file_name = Rails.root.join('tmp', 'testcsv.csv')
+    File.open(@file_name, 'w') { |f| f.write('a,b,c') }
+  end
+
+  after(:all) do
+    File.delete(@file_name) if File.exist?(@file_name)
+  end
+
+  before do
+    @aws_vars.each { |var| ENV[var] = 'Dummy Value' }
+  end
+
+  def run_command_redirected(cmd)
+    `#{cmd} #{REDIRECT_STDERR}`
+  end
+
+  # Note the use of `2>&1` which forces STDERR to STDOUT to let us check failures
+
+  it 'raises an error if no file name passed' do
+    captured_stdout = `thor export:upload_export_to_aws 2>&1`
+    expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
+    expect(captured_stdout).to include('was called with no arguments')
+  end
+
+  it 'raises an error if the AWS ENV Variables are not set' do
+    @aws_vars.each { |var| ENV.delete(var) }
+    captured_stdout = `thor export:upload_export_to_aws #{@file_name} 2>&1`
+    expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
+    expect(captured_stdout).to include('is required to be set as an environment variable')
+  end
+
+  it 'raises an error if the file does not exist' do
+    captured_stdout = `thor export:upload_export_to_aws dummyfile.csv 2>&1`
+    expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
+    expect(captured_stdout).to include('does not exist')
+  end
+end

--- a/spec/features/upload_aws_spec.rb
+++ b/spec/features/upload_aws_spec.rb
@@ -25,20 +25,20 @@ RSpec.describe 'Exporting Children as CSV', type: :feature do
   # Note the use of `2>&1` which forces STDERR to STDOUT to let us check failures
 
   it 'raises an error if no file name passed' do
-    captured_stdout = `thor export:upload_export_to_aws 2>&1`
+    captured_stdout = run_command_redirected('thor export:upload_export_to_aws')
     expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
     expect(captured_stdout).to include('was called with no arguments')
   end
 
   it 'raises an error if the AWS ENV Variables are not set' do
     @aws_vars.each { |var| ENV.delete(var) }
-    captured_stdout = `thor export:upload_export_to_aws #{@file_name} 2>&1`
+    captured_stdout = run_command_redirected("thor export:upload_export_to_aws #{@file_name}")
     expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
     expect(captured_stdout).to include('is required to be set as an environment variable')
   end
 
   it 'raises an error if the file does not exist' do
-    captured_stdout = `thor export:upload_export_to_aws dummyfile.csv 2>&1`
+    captured_stdout = run_command_redirected('thor export:upload_export_to_aws dummyfile.csv')
     expect(captured_stdout).not_to include(SUCCESS_MESSAGE)
     expect(captured_stdout).to include('does not exist')
   end


### PR DESCRIPTION
I broke down the approach for exporting and uploading into two separate Thor tasks:

1) `thor export:last_x_days` which takes a `DAYS` parameter and goes from midnight that many days ago to midnight of the current day. So if run on a Monday 6/15 it would go from Monday 6/8 at 0000 through Sunday 6/14 at 2359

2) `thor export:upload_export_to_aws` which takes the file we created above and uploads it to an S3 bucket as specified by 4 environment variables - `AWS_REGION`, `AWS_EXPORT_UPLOAD_BUCKET`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. It uses the file name of the export file as the key to upload to in the bucket.

I would expect us to call these using a crontab file which runs every Monday at 0200 and contains the following two lines:

```
thor export:last_x_days 7 tmp/$(date +'%Y-%m-%d').csv
thor export:upload_export_to_aws tmp/$(date +'%Y-%m-%d').csv
```

But this PR does not implement the CRONTAB nor the changes to the Dockerfile to enable that on Aptible.