### PR TITLE
Adds supercronic and crontab for running export/upload

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,18 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
  && apt-get update \
  && apt-get install -y groff
 
+# Supercronic for cron jobs
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
+
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+ ADD config/crontab /app/crontab
+
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 WORKDIR /app
@@ -27,4 +39,5 @@ RUN set -a \
 
 EXPOSE 3000
 
+CMD ["supercronic", "/app/crontab"]
 CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0", "-p", "3000"]

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ Use Outside-In Test-Driven Development to implement a new screen:
 : Export children (by default, only completely submitted children) to FILE (by default `tmp/all.csv`). Run `thor help export:children` for more options
 
 ### Deployment Environment Variables
-`RAILS_ENV`: Rails environment. Currently one of `demo`, `staging`, `production`
-`RAILS_MASTER_KEY`: For decrypting env vars loaded from credentials file.
-`DATABASE_URL`: Postgres db connection string.
-`SENTRY_DSN`: [Sentry](https://docs.sentry.io/clients/ruby/) configuration.
-`EXPERIMENT_OVER`: For use in early launch experiments. Setting to `1` turns off `/early` endpoint.
-`SKYLIGHT_AUTHENTICATION`: [Skylight](https://www.skylight.io/support/getting-started) configuration.
-`DEMO_BANNER`: For use in non-prod environments. Setting to `1` shows a demo banner.
-`AUTH_USERNAME`: If set, the application will use `AUTH_USERNAME` and `AUTH_PASSWORD` via http authentication for each request.
-`METRICS_USERNAME` / `METRICS_PASSWORD`: Required to `access `/metrics`
-`GOOGLE_PLACES_API_KEY`: API key for [Google Places API](https://developers.google.com/places/web-service/autocomplete) for use in address autocomplete.
+- `RAILS_ENV`: Rails environment. Currently one of `demo`, `staging`, `production`
+- `RAILS_MASTER_KEY`: For decrypting env vars loaded from credentials file.
+- `DATABASE_URL`: Postgres db connection string.
+- `SENTRY_DSN`: [Sentry](https://docs.sentry.io/clients/ruby/) configuration.
+- `EXPERIMENT_OVER`: For use in early launch experiments. Setting to `1` turns off `/early` endpoint.
+- `SKYLIGHT_AUTHENTICATION`: [Skylight](https://www.skylight.io/support/getting-started) configuration.
+- `DEMO_BANNER`: For use in non-prod environments. Setting to `1` shows a demo banner.
+- `AUTH_USERNAME`: If set, the application will use `AUTH_USERNAME` and `AUTH_PASSWORD` via http authentication for each request.
+- `METRICS_USERNAME` / `METRICS_PASSWORD`: Required to access `/metrics`
+- `GOOGLE_PLACES_API_KEY`: API key for [Google Places API](https://developers.google.com/places/web-service/autocomplete) for use in address autocomplete.
+- `AWS_REGION`: Required for `thor export:upload_export_to_aws`
+- `AWS_EXPORT_UPLOAD_BUCKET`: Required for `thor export:upload_export_to_aws`
+- `AWS_ACCESS_KEY_ID`: Required for `thor export:upload_export_to_aws`
+- `AWS_SECRET_ACCESS_KEY`: Required for `thor export:upload_export_to_aws`

--- a/config/crontab
+++ b/config/crontab
@@ -1,0 +1,1 @@
+0 2 * * 1  thor export:last_x_days 7 tmp/$(date +'%Y-%m-%d').csv; thor export:upload_export_to_aws tmp/$(date +'%Y-%m-%d').csv

--- a/lib/tasks/export.thor
+++ b/lib/tasks/export.thor
@@ -36,7 +36,8 @@ class Export < Thor
     raise Thor::Error, "ERROR: #{file} does not exist" unless File.exist?(file)
 
     s3 = Aws::S3::Resource.new
-    obj = s3.bucket(ENV['AWS_EXPORT_UPLOAD_BUCKET']).object(file)
+    filename = file.split('/')[-1]
+    obj = s3.bucket(ENV['AWS_EXPORT_UPLOAD_BUCKET']).object("mn/#{Rails.env}/#{filename}")
     obj.upload_file(file)
     puts 'Upload Complete!'
   end


### PR DESCRIPTION
Based on the [Aptible docs](https://www.aptible.com/documentation/faq/deploy/scheduled-tasks.html) to run scheduled jobs we needed to install [Supercronic](https://github.com/aptible/supercronic#installation) and then add a `crontab`. This sets up a cron job to run every [Monday at 2am](https://crontab.guru/#0_2_*_*_1) and exports the csv then uploads it to AWS.

NOTE that to run this will need four AWS Environment variables set up to point it to the appropriate bucket and credentials. You can test the cron script from the command line with the following command, replacing the variables with the appropriate values:

`thor export:last_x_days 7 tmp/$(date +'%Y-%m-%d').csv; AWS_REGION=[AWSREGION] AWS_EXPORT_UPLOAD_BUCKET=[BUCKETNAME] AWS_ACCESS_KEY_ID=[ACCESSKEYID] AWS_SECRET_ACCESS_KEY=[SECRETACCESSKEY] thor export:upload_export_to_aws tmp/$(date +'%Y-%m-%d').csv`